### PR TITLE
✨ i18n Fix [components/landing-navbar.tsx] 

### DIFF
--- a/components/landing-navbar.tsx
+++ b/components/landing-navbar.tsx
@@ -26,7 +26,7 @@ export const LandingNavbar = () => {
       <div className="flex items-center gap-x-2">
         <Link href={isSignedIn ? "/dashboard" : "/sign-up"}>
           <Button variant="outline" className="rounded-full">
-            Get Started
+          {isSignedIn ? "Dashboard" : "Get Started"}
           </Button>
         </Link>
       </div>


### PR DESCRIPTION
This is a simple fix that changes `Get Started` to``Dashboard` if you are logged in.