### PR TITLE
Add asChild to SheetTrigger 

### DIFF
--- a/components/mobile-sidebar.tsx
+++ b/components/mobile-sidebar.tsx
@@ -26,7 +26,7 @@ export const MobileSidebar = ({
 
   return (
     <Sheet>
-      <SheetTrigger>
+      <SheetTrigger asChild>
         <Button variant="ghost" size="icon" className="md:hidden">
           <Menu />
         </Button>


### PR DESCRIPTION
Following shadcn example. Resolves a console error 'validateDOMNesting(...): <button> cannot appear as a descendant of <button>.'